### PR TITLE
Default RO + assume PowerUser

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -91,15 +91,17 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
+
   AWSIAMDeveloperUsersGroup:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/PowerUserAccess
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
         - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - !Ref AWSIAMEnforceMfaPolicy
         - !Ref AWSIAMDynamoDenyDeletePolicy
         - !Ref AWSIAMRdsDenyDeletePolicy
+
   AWSIAMAdminRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -115,7 +117,14 @@ Resources:
             Action:
               - "sts:AssumeRole"
       Path: "/"
-  
+
+  AWSIAMPowerUserRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/PowerUserAccess
+      Path: "/"
+
   AWSIAMDynamoDenyDeletePolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
@@ -129,6 +138,7 @@ Resources:
               - dynamodb:UpdateTable
               - dynamodb:DeleteTable
             Resource: "*"
+
   AWSIAMRdsDenyDeletePolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
@@ -143,6 +153,7 @@ Resources:
               - rds:DeleteDBInstance
               - rds:DeleteDBSnapshot
             Resource: "*"
+
   AWSIAMAdminRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:
@@ -157,13 +168,15 @@ Resources:
       Roles:
         -
           !Ref AWSIAMAdminRole
-  AWSIAMInstanceProfile:
+
+  AWSIAMAdminInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       Path: "/"
       Roles:
         -
           !Ref "AWSIAMAdminRole"
+
   # resources for auditors
   AWSIAMAuditorAccessPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
@@ -183,6 +196,7 @@ Resources:
             - sqs:ReceiveMessage
             - sdb:Select
             Resource: "*"
+
   AWSIAMAuditorsGroup:
     Type: 'AWS::IAM::Group'
     Properties:

--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -16,6 +16,7 @@ Resources:
       UserName: x.schildwachter@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
+        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -25,6 +26,7 @@ Resources:
       UserName: khai.do@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
+        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -34,6 +36,7 @@ Resources:
       UserName: bruce.hoff@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
+        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -70,6 +73,7 @@ Resources:
       UserName: meredith.slota@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
+        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -97,8 +101,31 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/ReadOnlyAccess
-        - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - !Ref AWSIAMEnforceMfaPolicy
+
+  AWSIAMBillingUsersGroup:
+    Type: "AWS::IAM::Group"
+    Properties:
+      ManagedPolicyArns:
+        - !Ref AWSIAMBillingAccessPolicy
+
+  AWSIAMBillingAccessPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument: 
+        Version: "2012-10-17"
+        Statement:
+          - 
+            Effect: "Allow"
+            Action:
+              - aws-portal:*Billing
+              - awsbillingconsole:*Billing
+              - aws-portal:*Usage
+              - awsbillingconsole:*Usage
+              - budgets:ViewBudget
+              - budgets:ModifyBudget
+              - cur:*
+            Resource: "*"
 
   AWSIAMAdminRole:
     Type: "AWS::IAM::Role"
@@ -121,6 +148,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
+        - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - !Ref AWSIAMDynamoDenyDeletePolicy
         - !Ref AWSIAMRdsDenyDeletePolicy
       Path: "/"

--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -99,8 +99,6 @@ Resources:
         - arn:aws:iam::aws:policy/ReadOnlyAccess
         - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - !Ref AWSIAMEnforceMfaPolicy
-        - !Ref AWSIAMDynamoDenyDeletePolicy
-        - !Ref AWSIAMRdsDenyDeletePolicy
 
   AWSIAMAdminRole:
     Type: "AWS::IAM::Role"
@@ -123,6 +121,8 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
+        - !Ref AWSIAMDynamoDenyDeletePolicy
+        - !Ref AWSIAMRdsDenyDeletePolicy
       Path: "/"
 
   AWSIAMDynamoDenyDeletePolicy:

--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -16,7 +16,6 @@ Resources:
       UserName: x.schildwachter@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -26,7 +25,6 @@ Resources:
       UserName: khai.do@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -36,7 +34,6 @@ Resources:
       UserName: bruce.hoff@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -73,7 +70,6 @@ Resources:
       UserName: meredith.slota@sagebase.org
       Groups:
         - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -103,14 +99,42 @@ Resources:
         - arn:aws:iam::aws:policy/ReadOnlyAccess
         - !Ref AWSIAMEnforceMfaPolicy
 
-  AWSIAMBillingUsersGroup:
-    Type: "AWS::IAM::Group"
+  AWSIAMAdminRole:
+    Type: "AWS::IAM::Role"
     Properties:
-      ManagedPolicyArns:
-        - !Ref AWSIAMBillingAccessPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !GetAtt AWSIAMXavierSchildwachterUser.Arn
+                - !GetAtt AWSIAMKhaiDoUser.Arn
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+
+  AWSIAMBillingUserRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !GetAtt AWSIAMXavierSchildwachterUser.Arn
+                - !GetAtt AWSIAMKhaiDoUser.Arn
+                - !GetAtt AWSIAMBruceHoffUser.Arn
+                - !GetAtt AWSIAMMeredithSlotaUser.Arn
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
 
   AWSIAMBillingAccessPolicy:
-    Type: "AWS::IAM::ManagedPolicy"
+    Type: "AWS::IAM::Policy"
     Properties:
       PolicyDocument: 
         Version: "2012-10-17"
@@ -126,6 +150,9 @@ Resources:
               - budgets:ModifyBudget
               - cur:*
             Resource: "*"
+      Roles:
+        -
+          !Ref AWSIAMBillingUserRole
 
   AWSIAMAdminRole:
     Type: "AWS::IAM::Role"


### PR DESCRIPTION
By default, devs have read-only. Adding an AssumeRolePolicyDocument with users would give these users the ability to escalade to PowerUsers.