### PR TITLE
Removing the IAM user of Nick Grosenbacher from the accounts definition

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -83,16 +83,6 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
-  AWSIAMNickGrosenbacherUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: nick.grosenbacher@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
   AWSIAMAaronHaydenUser:
     Type: 'AWS::IAM::User'
     Properties:


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/IT-775

Console access, APIKEYs, and MFA device are already removed