### PR TITLE
Revert "Removing the IAM user of Nick Grosenbacher from the accounts definition"

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -93,6 +93,16 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
+  AWSIAMNickGrosenbacherUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      UserName: nick.grosenbacher@sagebase.org
+      Groups:
+        - !Ref AWSIAMAllUsersGroup
+        - !Ref AWSIAMDeveloperUsersGroup
+      LoginProfile:
+        Password: !Ref InitNewUserPassword
+        PasswordResetRequired: true
   AWSIAMAaronHaydenUser:
     Type: 'AWS::IAM::User'
     Properties:


### PR DESCRIPTION
I need access to the static.synapse.org S3 bucket (which I think lives in this account)